### PR TITLE
Remove mongodb credentials from this file

### DIFF
--- a/server/config/default.json
+++ b/server/config/default.json
@@ -1,5 +1,5 @@
 {
- "mongoUri":"mongodb+srv://christian:dianmenu230408@cluster.ccb1y.mongodb.net/pratama?retryWrites=true&w=majority" ,
+ "mongoUri":"" ,
  "jwtSecret":"myjwtsecret"
 
 }


### PR DESCRIPTION
The production credentials are in this file please remove the mongodb credentials. Or set this repository to private.

I did a test to connect and list the databases:
```
Connected to mongo server.
Databases:
 - pratama
 - admin
 - local
```

Remember when removing the credentials please also make sure you clear the commit history:
https://stackoverflow.com/questions/13716658/how-to-delete-all-commit-history-in-github